### PR TITLE
Panning gesture change

### DIFF
--- a/src/components/FlowCanvas.jsx
+++ b/src/components/FlowCanvas.jsx
@@ -431,6 +431,10 @@ const FlowCanvas = ({ conversationData }) => {
             defaultViewport={{ x: 0, y: 0, zoom: 0.8 }}
             minZoom={0.1}
             maxZoom={2}
+            panOnDrag={[1, 2]}
+            panOnScroll={true}
+            zoomOnScroll={true}
+            zoomOnPinch={true}
           >
             <Controls className="!bottom-4 !left-4" />
             <MiniMap


### PR DESCRIPTION
Change gesture behavior where two-finger movement pans the canvas but still retain the pinch to zoom functionality. Keeps user experience in line with most other tools like Figma by allowing users to pan the canvas with a two-finger movement while still retaining the pinch to zoom functionality.